### PR TITLE
Add appeal interface for ride orders

### DIFF
--- a/park/parks/commo/appeal/index.js
+++ b/park/parks/commo/appeal/index.js
@@ -1,0 +1,10 @@
+import { post } from '../request.js'
+
+// 调用后台申诉接口，端口为8181
+const baseUrl = 'http://localhost:8181/appeal'
+
+export default {
+  add(data) {
+    return post(`${baseUrl}/add`, data)
+  }
+}

--- a/park/parks/pages.json
+++ b/park/parks/pages.json
@@ -79,15 +79,21 @@
 					"navigationBarTitleText": "场内详情",
 					"enablePullDownRefresh": false
 				}
-			}, {
-				"path": "orderList/orderList",
-				"style": {
-					"navigationBarTitleText": "历史订单",
-					"enablePullDownRefresh": false
-				}
-			}]
-		}
-	],
+                        }, {
+                                "path": "orderList/orderList",
+                                "style": {
+                                        "navigationBarTitleText": "历史订单",
+                                        "enablePullDownRefresh": false
+                                }
+                        }, {
+                                "path": "appeal/appeal",
+                                "style": {
+                                        "navigationBarTitleText": "订单申诉",
+                                        "enablePullDownRefresh": false
+                                }
+                        }]
+                }
+        ],
 	"globalStyle": {
 		"navigationBarTextStyle": "black",
 		"navigationBarTitleText": "uni-app",

--- a/park/parks/pagesB/appeal/appeal.vue
+++ b/park/parks/pagesB/appeal/appeal.vue
@@ -1,0 +1,51 @@
+<template>
+  <view>
+    <tm-message ref="toast"></tm-message>
+    <tm-form @submit="submit">
+      <tm-sheet :margin="[32,32]">
+        <tm-input v-model="form.content" name="content" :height="120" input-type="textarea" placeholder="请输入申诉内容" required></tm-input>
+        <view class="mt-24">
+          <tm-button block navtie-type="form">提交申诉</tm-button>
+        </view>
+      </tm-sheet>
+    </tm-form>
+  </view>
+</template>
+
+<script>
+import appeal from '@/commo/appeal'
+export default {
+  data(){
+    return {
+      form:{
+        content:'',
+        vid:null
+      }
+    }
+  },
+  onLoad(query){
+    if(query && query.id){
+      this.form.vid = query.id
+    }
+  },
+  methods:{
+    submit(e){
+      if(e===false){
+        this.$refs.toast.show({model:'warn',label:'请填写申诉内容'})
+        return
+      }
+      appeal.add(this.form).then(res=>{
+        if(res.code===200){
+          this.$refs.toast.show({model:'success',label:'提交成功'})
+          this.$back()
+        }else{
+          this.$refs.toast.show({model:'error',label:res.msg||'提交失败'})
+        }
+      })
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/park/parks/pagesB/orderList/orderList.vue
+++ b/park/parks/pagesB/orderList/orderList.vue
@@ -1,32 +1,35 @@
 <template>
 	<view>
-		<view class="mt-10" v-for="item in data" :key="item.id" >
-			<tm-sheet :margin="[32, 20]">
-				<tm-row>
-					<tm-col grid="3"><tm-images round="4" :height="200" model="aspectFill" :previmage="false"
-							:width="150" :src="item.picUrl"></tm-images></tm-col>
-					<tm-col grid="9">
-						<view class="text-align-left ml-20">
-							<view>
-								<span class="text-grey">支付人：{{item.nickName}}</span>
-							</view>
-							<view>
-								<span class="text-grey">停车场名称：{{item.parkName}}</span>
-							</view>	
-							<view>
-								<span class="text-grey">支付金额：{{item.price}}</span>
-							</view>
-							<view>
-								<span class="text-grey">支付时间：{{item.createTime}}</span>
-							</view>
-							
-							
-						</view>
-					</tm-col>
-				</tm-row>
-				
-			</tm-sheet>
-		</view>
+                <view class="mt-10" v-for="item in data" :key="item.id" >
+                        <tm-sheet :margin="[32, 20]" :round="6" :shadow="2">
+                                <tm-row>
+                                        <tm-col grid="3"><tm-images round="4" :height="200" model="aspectFill" :previmage="false"
+                                                        :width="150" :src="item.picUrl"></tm-images></tm-col>
+                                        <tm-col grid="9">
+                                                <view class="text-align-left ml-20">
+                                                        <view>
+                                                                <span class="text-grey">支付人：{{item.nickName}}</span>
+                                                        </view>
+                                                        <view>
+                                                                <span class="text-grey">停车场名称：{{item.parkName}}</span>
+                                                        </view>
+                                                        <view>
+                                                                <span class="text-grey">支付金额：{{item.price}}</span>
+                                                        </view>
+                                                        <view>
+                                                                <span class="text-grey">支付时间：{{item.createTime}}</span>
+                                                        </view>
+                                                        <view class="flex flex-row mt-10">
+                                                                <tm-button size="s" :round="3" @click="toAppeal(item)">申诉</tm-button>
+                                                                <tm-button size="s" :round="3" color="green" class="ml-20" @click="rideAgain(item)">再次骑行</tm-button>
+                                                        </view>
+
+                                                </view>
+                                        </tm-col>
+                                </tm-row>
+
+                        </tm-sheet>
+                </view>
 	</view>
 </template>
 
@@ -39,17 +42,26 @@
 				data: []
 			}
 		},
-		mounted() {
-			const than = this
-			payOrder.list({}).then(res => {
-				
-				than.data = res.rows
-			})
-		},
-		methods: {
-
-		}
-	}
+                mounted() {
+                        const than = this
+                        payOrder.list({}).then(res => {
+                                than.data = res.rows
+                        })
+                },
+                methods: {
+                        toAppeal(item){
+                                uni.navigateTo({
+                                        url:`/pagesB/appeal/appeal?id=${item.id}`
+                                })
+                        },
+                        rideAgain(item){
+                                // 预留再次骑行功能，可跳转到停车场详情
+                                uni.navigateTo({
+                                        url:`/pagesB/parksDetail/parksDetail?id=${item.parkId}`
+                                })
+                        }
+                }
+        }
 </script>
 
 <style>


### PR DESCRIPTION
## Summary
- add appeal HTTP helper
- create ride appeal page in mini program
- enhance order list UI and add appeal button
- register new page route

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_684508943b2c833098930b163b54fbe8